### PR TITLE
XSLT Implementation

### DIFF
--- a/redex.xsl
+++ b/redex.xsl
@@ -1,0 +1,40 @@
+<?xml version='1.0' ?>
+
+<xsl:stylesheet version='1.0' xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <apply>
+      <xsl:apply-templates select="apply/*[1]" />
+    </apply>
+  </xsl:template>
+  <xsl:template match="apply">
+    <xsl:copy-of select="*" />
+    <xsl:copy-of select="following-sibling::node()" />
+  </xsl:template>
+  <xsl:template match="s">
+    <xsl:choose>
+      <xsl:when test="count(following-sibling::node())>2">
+        <xsl:copy-of select="following-sibling::node()[1]" />
+        <xsl:copy-of select="following-sibling::node()[3]" />
+        <apply>
+          <xsl:copy-of select="following-sibling::node()[2]" />
+          <xsl:copy-of select="following-sibling::node()[3]" />
+        </apply>
+        <xsl:copy-of select="following-sibling::node()[position()>3]" />
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy-of select="../*" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <xsl:template match="k">
+    <xsl:choose>
+      <xsl:when test="count(following-sibling::node())>1">
+        <xsl:copy-of select="following-sibling::node()[1]" />
+        <xsl:copy-of select="following-sibling::node()[position()>2]" />
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy-of select="../*" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Some thoughts:

I reduce apply as a redex on its own and take concatenation to mean application. This really makes it more of an SKapplyML or something. I also didn't include I as it seemed redundant (but we should put it in a namespace). I also lower-cased the combinators and didn't mark them as fun. I think we should use XML namespaces to determine reduction.

The XSLT does not find a fixpoint. I was thinking maybe I'd write a shell script to do this? I'd really like VBScript but I just don't seem to have a VBScript interpreter handy. VBScript is definitely needed to attract our enterprise clients, though. Or perhaps Java or JavaScript?

Should IKSML programs contain information about their complexity so the interpreter can bound the reductions? Seems like it needs to be a function of their input. Can you apply IKSML terms to themselves or only to atomic XML values?
